### PR TITLE
docker-compose で動かしている Chrome を見れたりするようにした

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: Dockerfile.dev
     environment:
       SELENIUM_REMOTE_URL: http://webdriver_chrome:4444/wd/hub
+      USE_XVFB: '${USE_XVFB}'
     env_file: .env
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,13 +16,11 @@ else
 
   Capybara.register_driver :remote_chrome do |app|
     url = ENV.fetch('SELENIUM_REMOTE_URL')
+    args = ['no-sandbox', 'disable-gpu']
+    args.push('headless') unless ENV.fetch('USE_XVFB') == 'true'
     caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
       'goog:chromeOptions' => {
-        'args' => [
-          'no-sandbox',
-          'headless',
-          'disable-gpu'
-        ]
+        'args' => args
       }
     )
     Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)


### PR DESCRIPTION
テスト環境でのみ
Ember.js アプリケーションが何故か表示されないという問題に
前のプルリクで遭遇した。

そこで一時的にコードを変更して対応したのだが
永続的に使えるようにしたいという気持ちから
今回のプルリクを作成した。

このプルリクでは

- 環境変数を設定することで webdriver_chrome を xvfb, VNC と共に起動できるようにする
- 環境変数を設定することで Headless ではない Chrome を RSpec から動かせるようにする

ということを実装している。

# 環境変数を設定することで webdriver_chrome を xvfb, VNC と共に起動できるようにする

これにより VNC クライアントで Webdriver が動いているコンテナに接続ができるようになる
つまりその中でブラウザが動いていればそれを見たり弄ったりできるようになる。
なお接続時にパスワードを聞かれるが
デフォルトで `secret` が設定されているのでそれを入力すれば良い。

# 環境変数を設定することで Headless ではない Chrome を RSpec から動かせるようにする

上の手順で VNC 接続はできるようにしたが
ブラウザが Headless で動いていると結局表示がされない。

というわけでブラウザも Headless **ではない** 状態で
動かせるようにしている。

----

両方とも環境変数で動作を変更できるようにすることで
普段の開発でテストを実行する時は
xvfb や VNC は起動せず Headless でテストが実行されるようになり
ちょっとだけ軽くなるはず。

そして、テスト環境のデバッグが必要になった時には
環境変数を設定して起動してあげることで
ブラウザにアクセスして JS のエラーなどをチェックできるようになる

# 気になるところ

webdriver_chrome の起動にも
RSpec の起動にもそれぞれ環境変数を設定する必要があるので
webdriver_chrome だけそういう状態で起動したら
RSpec もヘッドレスじゃない状態で Chrome を動かすようにしてほしいけど
流石に無理そうで諦めている

そもそもこの設定はそんなに使う機会が多くはないはずなので
何度も発生した時に再検討するぐらいの方針で考えている。