### PR TITLE
Update bootstrap4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'active_model_serializers', '~> 0.10.0'
-gem 'bootstrap-sass', '~> 3.4.1'
 gem 'devise'
 gem 'ember-cli-rails', github: 'thoughtbot/ember-cli-rails', ref: '1e56a03fb8437f52dfd450454c71cffda2981d66'
 gem 'ember-cli-rails-assets', github: 'seanpdoyle/ember-cli-rails-assets', branch: 'rely-on-engine-to-load-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,15 +82,10 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.2.0)
-      execjs (~> 2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     brakeman (5.2.1)
     builder (3.2.4)
     bullet (7.0.1)
@@ -346,7 +341,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   bootsnap (>= 1.1.0)
-  bootstrap-sass (~> 3.4.1)
   brakeman
   bullet
   byebug

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,3 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
-//
-//= require jquery
-//= require bootstrap-sprockets
-//

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,5 +13,6 @@
  */
 
 @import 'foundations';
+@import 'layouts';
 @import 'objects/components';
 @import 'pages/*';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,6 @@
  *
  */
 
-@import 'bootstrap';
 @import 'foundations';
 @import 'objects/components';
 @import 'pages/*';

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,0 +1,20 @@
+.l-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 50px;
+  padding: 0 20px;
+  background-color: #f8f9fa;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+
+  &__brand {
+    display: block;
+    font-size: 24px;
+    color: #111;
+  }
+
+  &__actions {
+    justify-content: flex-end;
+    color: #111;
+  }
+}

--- a/app/assets/stylesheets/layouts/_index.scss
+++ b/app/assets/stylesheets/layouts/_index.scss
@@ -1,0 +1,1 @@
+@import 'header';

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,9 +1,6 @@
-#header.l-header.navbar.navbar-default
-  .container-fluid
-    .navbar-header
-      = link_to root_path, class: "navbar-brand" do
-        Ember-rails TODO App
-    .collapse.navbar-collapse
-      .nav.navbar-nav.navbar-right
-        - if user_signed_in?
-          = link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'btn btn-default navbar-btn'
+%nav#header.l-header
+  = link_to root_path, class: "l-header__brand" do
+    Ember-rails TODO App
+  .l-header__actions
+    - if user_signed_in?
+      = link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'btn btn-default'

--- a/ember/todo-app/app/adapters/application.js
+++ b/ember/todo-app/app/adapters/application.js
@@ -1,13 +1,13 @@
-import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { underscore } from '@ember/string';
-import { pluralize } from 'ember-inflector';
+import JSONAPIAdapter from '@ember-data/adapter/json-api'
+import { underscore } from '@ember/string'
+import { pluralize } from 'ember-inflector'
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
-  namespace = 'api/v1';
+  namespace = 'api/v1'
 
   pathForType(type) {
-    const underscored = underscore(type);
-    return pluralize(underscored);
+    const underscored = underscore(type)
+    return pluralize(underscored)
   }
 
   headers = {

--- a/ember/todo-app/app/serializers/application.js
+++ b/ember/todo-app/app/serializers/application.js
@@ -1,12 +1,12 @@
-import { underscore } from '@ember/string';
-import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { underscore } from '@ember/string'
+import JSONAPISerializer from '@ember-data/serializer/json-api'
 
 export default class ApplicationSerializer extends JSONAPISerializer {
   keyForAttribute(attr) {
-    return underscore(attr);
+    return underscore(attr)
   }
 
   keyForRelationship(rawKey) {
-    return underscore(rawKey);
+    return underscore(rawKey)
   }
 }

--- a/ember/todo-app/ember-cli-build.js
+++ b/ember/todo-app/ember-cli-build.js
@@ -5,7 +5,7 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app')
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     'ember-bootstrap': {
-      bootstrapVersion: 3,
+      bootstrapVersion: 4,
       importBootstrapCSS: true,
       importBootstrapFont: true,
     },

--- a/ember/todo-app/package.json
+++ b/ember/todo-app/package.json
@@ -31,7 +31,7 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
-    "bootstrap": "^3.4.1",
+    "bootstrap": "^4.6.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.12.0",
     "ember-bootstrap": "^4.0.0",

--- a/ember/todo-app/tests/unit/adapters/application-test.js
+++ b/ember/todo-app/tests/unit/adapters/application-test.js
@@ -1,16 +1,16 @@
-import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit'
+import { setupTest } from 'ember-qunit'
 
-module('Unit | Adapter | application', function(hooks) {
-  setupTest(hooks);
+module('Unit | Adapter | application', function (hooks) {
+  setupTest(hooks)
 
-  test('should namespace equal "api/v1"', function(assert) {
-    const adapter = this.owner.lookup('adapter:application');
-    assert.equal(adapter.namespace, 'api/v1');
-  });
+  test('should namespace equal "api/v1"', function (assert) {
+    const adapter = this.owner.lookup('adapter:application')
+    assert.equal(adapter.namespace, 'api/v1')
+  })
 
-  test('pathForType でケバブケースはスネークケースにされた上に複数形にされる', function(assert) {
-    const adapter = this.owner.lookup('adapter:application');
-    assert.equal(adapter.pathForType('kebab-case'), 'kebab_cases');
-  });
-});
+  test('pathForType でケバブケースはスネークケースにされた上に複数形にされる', function (assert) {
+    const adapter = this.owner.lookup('adapter:application')
+    assert.equal(adapter.pathForType('kebab-case'), 'kebab_cases')
+  })
+})

--- a/ember/todo-app/yarn.lock
+++ b/ember/todo-app/yarn.lock
@@ -3197,10 +3197,10 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
-  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+bootstrap@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.1.tgz#bc25380c2c14192374e8dec07cf01b2742d222a2"
+  integrity sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==
 
 bower-config@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
ember-bootstrap で使用する Bootstrap を v4 にした
v3 は推奨されてないのと
ember-bootstrap のβ版では
Bootstrap v3 はサポートから外されているため。
https://github.com/kaliber5/ember-bootstrap/blob/master/CHANGELOG.md#boom-breaking-change-3