### PR TITLE
chore: Update ember-cli-rails and ember-cli-rails-assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'devise'
-gem 'ember-cli-rails', github: 'thoughtbot/ember-cli-rails', ref: '1e56a03fb8437f52dfd450454c71cffda2981d66'
-gem 'ember-cli-rails-assets', github: 'seanpdoyle/ember-cli-rails-assets', branch: 'rely-on-engine-to-load-helper'
+gem 'ember-cli-rails'
+gem 'ember-cli-rails-assets'
 gem 'hamlit-rails'
 gem 'jquery-rails'
 gem 'sassc-rails', '>= 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,3 @@
-GIT
-  remote: https://github.com/seanpdoyle/ember-cli-rails-assets.git
-  revision: 868f354822fa51d2052de28529c238413941adb9
-  branch: rely-on-engine-to-load-helper
-  specs:
-    ember-cli-rails-assets (0.6.2)
-
-GIT
-  remote: https://github.com/thoughtbot/ember-cli-rails.git
-  revision: 1e56a03fb8437f52dfd450454c71cffda2981d66
-  ref: 1e56a03fb8437f52dfd450454c71cffda2981d66
-  specs:
-    ember-cli-rails (0.11.0)
-      ember-cli-rails-assets (~> 0.6.2)
-      html_page (~> 0.1.0)
-      railties (>= 4.2)
-      terrapin (~> 0.6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -127,6 +109,13 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    ember-cli-rails (0.12.1)
+      ember-cli-rails-assets (>= 0.6.2, < 1.0)
+      html_page (~> 0.1.0)
+      railties (>= 4.2)
+      terrapin (~> 0.6.0)
+    ember-cli-rails-assets (0.7.0)
+      nokogiri
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -364,8 +353,8 @@ DEPENDENCIES
   committee-rails
   database_rewinder
   devise
-  ember-cli-rails!
-  ember-cli-rails-assets!
+  ember-cli-rails
+  ember-cli-rails-assets
   factory_bot_rails
   faker
   hamlit-rails


### PR DESCRIPTION
新しめの Rails に対応した版が正式リリースされたっぽいので置き換え