### PR TITLE
chore: Fix rubocop target versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
-  TargetRailsVersion: 5.2
+  TargetRailsVersion: 6.0
   Exclude:
     - "bin/**/*"
     - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   TargetRailsVersion: 5.2
   Exclude:
     - "bin/**/*"


### PR DESCRIPTION
Ruby 2.7 と Rails 6.0 を使っているのに
Ruby 2.6 と Rails 5.2 を target にしていたので修正した