### PR TITLE
test: Use capabilities instead of desired_capabilities

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -23,7 +23,7 @@ else
         'args' => args
       }
     )
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: url, capabilities: caps)
   end
 
   RSpec.configure do |config|


### PR DESCRIPTION
いつの間にか desired_capabilities が deprecated になっていたので
capabilities に差し替えた

ref: https://qiita.com/mass584/items/c30e0762050a10503da7