### PR TITLE
chore: Set ulimits for MySQL

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,11 @@ services:
       - "3306:3306"
     volumes:
       - ./db/mysql:/var/lib/mysql
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 26677
+        hard: 46677
 
   webdriver_chrome:
     image: selenium/standalone-chrome-debug


### PR DESCRIPTION
MySQL コンテナを実行するとやたらメモリを食うので制限をかけた
ref: https://github.com/docker-library/mysql/issues/579#issuecomment-1075119349