### PR TITLE
chore: fix spring minimum version to 4.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,9 +63,9 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'letter_opener_web', '~> 1.0'
   gem 'reek', require: false
-  gem 'spring'
+  gem 'spring', '>= 4.1.0'
   gem 'spring-commands-rspec'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '>= 2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,9 +424,9 @@ DEPENDENCIES
   sassc-rails (>= 2.1.0)
   selenium-webdriver
   simplecov (~> 0.17.1)
-  spring
+  spring (>= 4.1.0)
   spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen (>= 2.0.0)
   sprockets (~> 3.7.2)
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
To prevent spring from being intentionally downgraded